### PR TITLE
fix: np.NaN -> np.nan in describe_numeric_spark.py

### DIFF
--- a/src/ydata_profiling/model/spark/describe_numeric_spark.py
+++ b/src/ydata_profiling/model/spark/describe_numeric_spark.py
@@ -105,7 +105,7 @@ def describe_numeric_1d_spark(
     summary["p_negative"] = summary["n_negative"] / summary["n"]
     summary["range"] = summary["max"] - summary["min"]
     summary["iqr"] = summary["75%"] - summary["25%"]
-    summary["cv"] = summary["std"] / summary["mean"] if summary["mean"] else np.NaN
+    summary["cv"] = summary["std"] / summary["mean"] if summary["mean"] else np.nan
     summary["p_zeros"] = summary["n_zeros"] / summary["n"]
     summary["p_infinite"] = summary["n_infinite"] / summary["n"]
 


### PR DESCRIPTION
Encountered:
```AttributeError: `np.NaN` was removed in the NumPy 2.0 release. Use `np.nan` instead.```

similar to https://github.com/ydataai/ydata-profiling/pull/1649/files. I searched for more cases of `np.NaN` but this is the last one. 