### PR TITLE
fix: enable autoescape in jinja2 environment

### DIFF
--- a/src/ydata_profiling/report/presentation/flavours/html/templates.py
+++ b/src/ydata_profiling/report/presentation/flavours/html/templates.py
@@ -12,7 +12,7 @@ package_loader = jinja2.PackageLoader(
     "ydata_profiling", "report/presentation/flavours/html/templates"
 )
 jinja2_env = jinja2.Environment(
-    lstrip_blocks=True, trim_blocks=True, loader=package_loader
+    lstrip_blocks=True, trim_blocks=True, loader=package_loader, autoescape=jinja2.select_autoescape()
 )
 jinja2_env.filters["is_list"] = lambda x: isinstance(x, list)
 jinja2_env.filters["fmt_badge"] = fmt_badge


### PR DESCRIPTION
Autoescaping is recommended by the [jinja2 docs](https://jinja.palletsprojects.com/en/stable/api/#autoescaping) for security reasons, but is not yet enabled by default.

This PR enables it, which should prevent maliciously crafted datasets being used to create ydata-profiling reports containing XSS payloads. In the latest versions of ydata-profiling it is currently possible to perform these attacks.