### PR TITLE
fix: respect config option to disable progress bar in pandas summary

### DIFF
--- a/src/ydata_profiling/model/pandas/summary_pandas.py
+++ b/src/ydata_profiling/model/pandas/summary_pandas.py
@@ -94,7 +94,11 @@ def pandas_get_series_descriptions(
             for name, series in df.items()
         }
 
-        for future in tqdm(future_to_col.keys(), total=len(future_to_col)):
+        for future in tqdm(
+            future_to_col.keys(),
+            total=len(future_to_col),
+            disable=not config.progress_bar,
+        ):
             name, description = future.result()
             series_description[name] = description
 


### PR DESCRIPTION
### Fix: Respect config option to disable progress bar in pandas summary

#### Summary

This PR fixes an issue where the `progress_bar` configuration option in the `Settings` object was not being respected when running the pandas summary. Previously, the progress bar would always be shown, even if `progress_bar` was set to `False`.

#### Changes

- Pass the `disable=not config.progress_bar` argument to `tqdm` in [pandas_get_series_descriptions](cci:1://file:///home/andreas/projects/ydata-profiling/src/ydata_profiling/model/pandas/summary_pandas.py:69:0-103:61), ensuring that the progress bar can be disabled via configuration.

#### Motivation

This change allows users to suppress the progress bar when running profiling in environments where output should be minimal (e.g., automated scripts, CI pipelines, or Jupyter notebooks).

#### Additional Notes

- No breaking changes introduced.
- The default behavior remains unchanged; the progress bar is shown unless explicitly disabled in the config.

---

Let me know if any further changes are needed!