### PR TITLE
Added support for NBTest, for testing notebooks with assertions in the `Multi-software test` CI pipeline

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - master
       - develop
+      - nbtest
 
 env:
   YDATA_PROFILING_NO_ANALYTICS: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,8 +4,8 @@ on:
   pull_request:
   push:
     branches:
-      - master
-      - develop
+    - master
+    - develop
 
 env:
   YDATA_PROFILING_NO_ANALYTICS: false
@@ -15,49 +15,49 @@ jobs:
     name: Tests
     strategy:
       matrix:
-        os: [ubuntu-22.04]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
-        pandas: ["pandas>1.1"]
-        numpy: ["numpy>=1.21"]
+        os: [ ubuntu-22.04 ]
+        python-version: ["3.9", "3.10", "3.11", "3.12" ]
+        pandas: [ "pandas>1.1" ]
+        numpy: [ "numpy>=1.21" ]
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+    - uses: actions/checkout@v4
+    
+    - name: Setup python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: x64
+    
+    - uses: actions/cache@v4
+      if: startsWith(runner.os, 'Linux')
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-${{ matrix.pandas }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.pandas }}-pip-
+    - uses: actions/cache@v4
+      if: startsWith(runner.os, 'macOS')
+      with:
+        path: ~/Library/Caches/pip
+        key: ${{ runner.os }}-${{ matrix.pandas }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.pandas }}-pip-
+    - uses: actions/cache@v4
+      if: startsWith(runner.os, 'Windows')
+      with:
+        path: ~\AppData\Local\pip\Cache
+        key: ${{ runner.os }}-${{ matrix.pandas }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.pandas }}-pip-
+    - run: |
+        pip install --upgrade pip setuptools wheel
+        pip install ".[test]" "${{ matrix.pandas }}" "${{ matrix.numpy }}"
+    - run: echo "YDATA_PROFILING_NO_ANALYTICS=False" >> $GITHUB_ENV
+    - run: make install
 
-      - name: Setup python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          architecture: x64
-
-      - uses: actions/cache@v4
-        if: startsWith(runner.os, 'Linux')
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-${{ matrix.pandas }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.pandas }}-pip-
-      - uses: actions/cache@v4
-        if: startsWith(runner.os, 'macOS')
-        with:
-          path: ~/Library/Caches/pip
-          key: ${{ runner.os }}-${{ matrix.pandas }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.pandas }}-pip-
-      - uses: actions/cache@v4
-        if: startsWith(runner.os, 'Windows')
-        with:
-          path: ~\AppData\Local\pip\Cache
-          key: ${{ runner.os }}-${{ matrix.pandas }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.pandas }}-pip-
-      - run: |
-          pip install --upgrade pip setuptools wheel
-          pip install ".[test]" "${{ matrix.pandas }}" "${{ matrix.numpy }}"
-      - run: echo "YDATA_PROFILING_NO_ANALYTICS=False" >> $GITHUB_ENV
-      - run: make install
-
-      - run: make test
+    - run: make test
 
   coverage:
     name: Coverage
@@ -66,67 +66,68 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         python-version: ["3.12"]
-        pandas: ["pandas>1.1"]
-        numpy: ["numpy>=1.21"]
+        pandas: [ "pandas>1.1" ]
+        numpy: [ "numpy>=1.21" ]
 
     steps:
-      - uses: actions/checkout@v4
+    - uses: actions/checkout@v4
 
-      - name: Setup python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          architecture: x64
+    - name: Setup python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: x64
 
-      - uses: actions/cache@v4
-        if: startsWith(runner.os, 'Linux')
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-${{ matrix.pandas }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.pandas }}-pip-
-      - uses: actions/cache@v4
-        if: startsWith(runner.os, 'macOS')
-        with:
-          path: ~/Library/Caches/pip
-          key: ${{ runner.os }}-${{ matrix.pandas }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.pandas }}-pip-
-      - uses: actions/cache@v4
-        if: startsWith(runner.os, 'Windows')
-        with:
-          path: ~\AppData\Local\pip\Cache
-          key: ${{ runner.os }}-${{ matrix.pandas }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.pandas }}-pip-
-      - run: |
-          pip install --upgrade pip setuptools wheel
-          pip install ".[test]" "${{ matrix.pandas }}" "${{ matrix.numpy }}"
-          echo "YDATA_PROFILING_NO_ANALYTICS=False" >> $GITHUB_ENV
-      - run: make install
-      - run: make test_cov
+    - uses: actions/cache@v4
+      if: startsWith(runner.os, 'Linux')
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-${{ matrix.pandas }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.pandas }}-pip-
+    - uses: actions/cache@v4
+      if: startsWith(runner.os, 'macOS')
+      with:
+        path: ~/Library/Caches/pip
+        key: ${{ runner.os }}-${{ matrix.pandas }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.pandas }}-pip-
+    - uses: actions/cache@v4
+      if: startsWith(runner.os, 'Windows')
+      with:
+        path: ~\AppData\Local\pip\Cache
+        key: ${{ runner.os }}-${{ matrix.pandas }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.pandas }}-pip-
+    - run: |
+        pip install --upgrade pip setuptools wheel
+        pip install ".[test]" "${{ matrix.pandas }}" "${{ matrix.numpy }}"
+        echo "YDATA_PROFILING_NO_ANALYTICS=False" >> $GITHUB_ENV
+    - run: make install
 
-      - uses: actions/cache@v4
-        if: startsWith(runner.os, 'Windows')
-        with:
-          path: ~\AppData\Local\pip\Cache
-          key: ${{ runner.os }}-${{ matrix.pandas }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.pandas }}-pip-
-      - run: |
-          pip install --upgrade pip setuptools wheel
-          pip install ".[test]" "${{ matrix.pandas }}" "${{ matrix.numpy }}"
-      - run: make install
-      - run: make test_cov
-      - run: codecov -F py${{ matrix.python-version }}-${{ matrix.os }}-${{ matrix.pandas }}-${{ matrix.numpy }}
+    - run: make test_cov
+
+    - uses: actions/cache@v4
+      if: startsWith(runner.os, 'Windows')
+      with:
+        path: ~\AppData\Local\pip\Cache
+        key: ${{ runner.os }}-${{ matrix.pandas }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.pandas }}-pip-
+    - run: |
+        pip install --upgrade pip setuptools wheel
+        pip install ".[test]" "${{ matrix.pandas }}" "${{ matrix.numpy }}"
+    - run: make install
+    - run: make test_cov
+    - run: codecov -F py${{ matrix.python-version }}-${{ matrix.os }}-${{ matrix.pandas }}-${{ matrix.numpy }}
 
   test_spark:
     runs-on: ubuntu-24.04
     continue-on-error: false
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
-        pyspark-version: ["3.4", "3.5"]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
+        pyspark-version: [ "3.4" , "3.5" ]
 
     name: Tests Spark | Python ${{ matrix.python-version }} | PySpark ${{ matrix.pyspark-version }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,8 +4,9 @@ on:
   pull_request:
   push:
     branches:
-    - master
-    - develop
+      - master
+      - develop
+      - nbtest
 
 env:
   YDATA_PROFILING_NO_ANALYTICS: false
@@ -15,49 +16,49 @@ jobs:
     name: Tests
     strategy:
       matrix:
-        os: [ ubuntu-22.04 ]
-        python-version: ["3.9", "3.10", "3.11", "3.12" ]
-        pandas: [ "pandas>1.1" ]
-        numpy: [ "numpy>=1.21" ]
+        os: [ubuntu-22.04]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        pandas: ["pandas>1.1"]
+        numpy: ["numpy>=1.21"]
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v4
-    
-    - name: Setup python
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-        architecture: x64
-    
-    - uses: actions/cache@v4
-      if: startsWith(runner.os, 'Linux')
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-${{ matrix.pandas }}-pip-${{ hashFiles('**/requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.pandas }}-pip-
-    - uses: actions/cache@v4
-      if: startsWith(runner.os, 'macOS')
-      with:
-        path: ~/Library/Caches/pip
-        key: ${{ runner.os }}-${{ matrix.pandas }}-pip-${{ hashFiles('**/requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.pandas }}-pip-
-    - uses: actions/cache@v4
-      if: startsWith(runner.os, 'Windows')
-      with:
-        path: ~\AppData\Local\pip\Cache
-        key: ${{ runner.os }}-${{ matrix.pandas }}-pip-${{ hashFiles('**/requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.pandas }}-pip-
-    - run: |
-        pip install --upgrade pip setuptools wheel
-        pip install ".[test]" "${{ matrix.pandas }}" "${{ matrix.numpy }}"
-    - run: echo "YDATA_PROFILING_NO_ANALYTICS=False" >> $GITHUB_ENV
-    - run: make install
+      - uses: actions/checkout@v4
 
-    - run: make test
+      - name: Setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
+
+      - uses: actions/cache@v4
+        if: startsWith(runner.os, 'Linux')
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-${{ matrix.pandas }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.pandas }}-pip-
+      - uses: actions/cache@v4
+        if: startsWith(runner.os, 'macOS')
+        with:
+          path: ~/Library/Caches/pip
+          key: ${{ runner.os }}-${{ matrix.pandas }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.pandas }}-pip-
+      - uses: actions/cache@v4
+        if: startsWith(runner.os, 'Windows')
+        with:
+          path: ~\AppData\Local\pip\Cache
+          key: ${{ runner.os }}-${{ matrix.pandas }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.pandas }}-pip-
+      - run: |
+          pip install --upgrade pip setuptools wheel
+          pip install ".[test]" "${{ matrix.pandas }}" "${{ matrix.numpy }}"
+      - run: echo "YDATA_PROFILING_NO_ANALYTICS=False" >> $GITHUB_ENV
+      - run: make install
+
+      - run: make test
 
   coverage:
     name: Coverage
@@ -66,68 +67,67 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         python-version: ["3.12"]
-        pandas: [ "pandas>1.1" ]
-        numpy: [ "numpy>=1.21" ]
+        pandas: ["pandas>1.1"]
+        numpy: ["numpy>=1.21"]
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Setup python
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-        architecture: x64
+      - name: Setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
 
-    - uses: actions/cache@v4
-      if: startsWith(runner.os, 'Linux')
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-${{ matrix.pandas }}-pip-${{ hashFiles('**/requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.pandas }}-pip-
-    - uses: actions/cache@v4
-      if: startsWith(runner.os, 'macOS')
-      with:
-        path: ~/Library/Caches/pip
-        key: ${{ runner.os }}-${{ matrix.pandas }}-pip-${{ hashFiles('**/requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.pandas }}-pip-
-    - uses: actions/cache@v4
-      if: startsWith(runner.os, 'Windows')
-      with:
-        path: ~\AppData\Local\pip\Cache
-        key: ${{ runner.os }}-${{ matrix.pandas }}-pip-${{ hashFiles('**/requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.pandas }}-pip-
-    - run: |
-        pip install --upgrade pip setuptools wheel
-        pip install ".[test]" "${{ matrix.pandas }}" "${{ matrix.numpy }}"
-        echo "YDATA_PROFILING_NO_ANALYTICS=False" >> $GITHUB_ENV
-    - run: make install
+      - uses: actions/cache@v4
+        if: startsWith(runner.os, 'Linux')
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-${{ matrix.pandas }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.pandas }}-pip-
+      - uses: actions/cache@v4
+        if: startsWith(runner.os, 'macOS')
+        with:
+          path: ~/Library/Caches/pip
+          key: ${{ runner.os }}-${{ matrix.pandas }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.pandas }}-pip-
+      - uses: actions/cache@v4
+        if: startsWith(runner.os, 'Windows')
+        with:
+          path: ~\AppData\Local\pip\Cache
+          key: ${{ runner.os }}-${{ matrix.pandas }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.pandas }}-pip-
+      - run: |
+          pip install --upgrade pip setuptools wheel
+          pip install ".[test]" "${{ matrix.pandas }}" "${{ matrix.numpy }}"
+          echo "YDATA_PROFILING_NO_ANALYTICS=False" >> $GITHUB_ENV
+      - run: make install
+      - run: make test_cov
 
-    - run: make test_cov
-
-    - uses: actions/cache@v4
-      if: startsWith(runner.os, 'Windows')
-      with:
-        path: ~\AppData\Local\pip\Cache
-        key: ${{ runner.os }}-${{ matrix.pandas }}-pip-${{ hashFiles('**/requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.pandas }}-pip-
-    - run: |
-        pip install --upgrade pip setuptools wheel
-        pip install ".[test]" "${{ matrix.pandas }}" "${{ matrix.numpy }}"
-    - run: make install
-    - run: make test_cov
-    - run: codecov -F py${{ matrix.python-version }}-${{ matrix.os }}-${{ matrix.pandas }}-${{ matrix.numpy }}
+      - uses: actions/cache@v4
+        if: startsWith(runner.os, 'Windows')
+        with:
+          path: ~\AppData\Local\pip\Cache
+          key: ${{ runner.os }}-${{ matrix.pandas }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.pandas }}-pip-
+      - run: |
+          pip install --upgrade pip setuptools wheel
+          pip install ".[test]" "${{ matrix.pandas }}" "${{ matrix.numpy }}"
+      - run: make install
+      - run: make test_cov
+      - run: codecov -F py${{ matrix.python-version }}-${{ matrix.os }}-${{ matrix.pandas }}-${{ matrix.numpy }}
 
   test_spark:
     runs-on: ubuntu-24.04
     continue-on-error: false
     strategy:
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
-        pyspark-version: [ "3.4" , "3.5" ]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        pyspark-version: ["3.4", "3.5"]
 
     name: Tests Spark | Python ${{ matrix.python-version }} | PySpark ${{ matrix.pyspark-version }}
 
@@ -169,4 +169,3 @@ jobs:
           make install
           pip install ".[test]"
           make test_spark
-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - master
       - develop
-      - nbtest
 
 env:
   YDATA_PROFILING_NO_ANALYTICS: false

--- a/Makefile
+++ b/Makefile
@@ -14,14 +14,9 @@ test_spark:
 	ydata_profiling -h
 
 test_cov:
+	pytest --cov=. --cov-append --nbtest tests/notebooks/
 	pytest --cov=. tests/unit/
 	pytest --cov=. --cov-append tests/issues/
-
-	# This environment variable allows NBTest assertions to be executed, as NBTest does not have coverage support.
-	export 'NBTEST_RUN_ASSERTS'='1'
-	pytest --cov=. --cov-append --nbval tests/notebooks/
-	export 'NBTEST_RUN_ASSERTS'='0'
-
 	ydata_profiling -h
 
 examples:

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@ docs:
 	mkdocs build
 
 test:
+	pytest --nbtest tests/notebooks/
 	pytest tests/unit/
 	pytest tests/issues/
-	pytest --nbtest tests/notebooks/
 	ydata_profiling -h
 
 test_spark:

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ docs:
 test:
 	pytest tests/unit/
 	pytest tests/issues/
-	pytest --nbval tests/notebooks/
+	pytest --nbtest tests/notebooks/
 	ydata_profiling -h
 
 test_spark:
@@ -16,7 +16,12 @@ test_spark:
 test_cov:
 	pytest --cov=. tests/unit/
 	pytest --cov=. --cov-append tests/issues/
+
+	# This environment variable allows NBTest assertions to be executed, as NBTest does not have coverage support.
+	export 'NBTEST_RUN_ASSERTS'='1'
 	pytest --cov=. --cov-append --nbval tests/notebooks/
+	export 'NBTEST_RUN_ASSERTS'='0'
+
 	ydata_profiling -h
 
 examples:

--- a/make.bat
+++ b/make.bat
@@ -12,7 +12,7 @@ IF "%1%" == "docs" (
 IF "%1" == "test" (
     pytest tests/unit/
     pytest tests/issues/
-    pytest --nbval tests/notebooks/
+    pytest --nbtest tests/notebooks/
     ECHO "Tests completed!"
     GOTO end
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ build-backend = "setuptools.build_meta"
 requires = [
     "setuptools>=72.0.0,<80.0.0",
     "setuptools-scm>=8.0.0,<9.0.0",
-    "wheel>=0.38.4,<1.0.0"
+    "wheel>=0.38.4,<1.0.0",
 ]
 
 [packaging]
@@ -12,13 +12,18 @@ package_name = "ydata-profiling"
 [project]
 name = "ydata-profiling"
 requires-python = ">=3.7,<3.13"
-authors = [
-    {name = "YData Labs Inc", email = "opensource@ydata.ai"}
-]
+authors = [{ name = "YData Labs Inc", email = "opensource@ydata.ai" }]
 description = "Generate profile report for pandas DataFrame"
-keywords = ["pandas", "data-science", "data-analysis", "python", "jupyter", "ipython"]
+keywords = [
+    "pandas",
+    "data-science",
+    "data-analysis",
+    "python",
+    "jupyter",
+    "ipython",
+]
 readme = "README.md"
-license = {file = "LICENSE.md"}
+license = { file = "LICENSE.md" }
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Topic :: Software Development :: Build Tools",
@@ -70,9 +75,7 @@ dependencies = [
     "numba>=0.56.0, <=0.61",
 ]
 
-dynamic = [
-    "version",
-]
+dynamic = ["version"]
 
 [project.optional-dependencies]
 dev = [
@@ -99,10 +102,7 @@ docs = [
     "mkdocs-badges",
 ]
 
-notebook = [
-    "jupyter>=1.0.0",
-    "ipywidgets>=7.5.1",
-]
+notebook = ["jupyter>=1.0.0", "ipywidgets>=7.5.1"]
 
 # this provides the recommended pyspark and pyarrow versions for spark to work on pandas-profiling
 # note that if you are using pyspark 2.3 or 2.4 and pyarrow >= 0.15, you might need to
@@ -121,14 +121,13 @@ test = [
     "codecov",
     "pytest-cov",
     "nbval",
+    "nbtest-gen",
     "pyarrow",
     "twine>=3.1.1",
     "kaggle",
 ]
 
-unicode= [
-    "tangled-up-in-unicode==0.2.0",
-]
+unicode = ["tangled-up-in-unicode==0.2.0"]
 
 [project.urls]
 Homepage = "https://ydata.ai"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,6 @@ test = [
     "coverage>=6.5, <8",
     "codecov",
     "pytest-cov",
-    "nbval",
     "nbtest-gen",
     "pyarrow",
     "twine>=3.1.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ build-backend = "setuptools.build_meta"
 requires = [
     "setuptools>=72.0.0,<80.0.0",
     "setuptools-scm>=8.0.0,<9.0.0",
-    "wheel>=0.38.4,<1.0.0",
+    "wheel>=0.38.4,<1.0.0"
 ]
 
 [packaging]
@@ -12,18 +12,13 @@ package_name = "ydata-profiling"
 [project]
 name = "ydata-profiling"
 requires-python = ">=3.7,<3.13"
-authors = [{ name = "YData Labs Inc", email = "opensource@ydata.ai" }]
-description = "Generate profile report for pandas DataFrame"
-keywords = [
-    "pandas",
-    "data-science",
-    "data-analysis",
-    "python",
-    "jupyter",
-    "ipython",
+authors = [
+    {name = "YData Labs Inc", email = "opensource@ydata.ai"}
 ]
+description = "Generate profile report for pandas DataFrame"
+keywords = ["pandas", "data-science", "data-analysis", "python", "jupyter", "ipython"]
 readme = "README.md"
-license = { file = "LICENSE.md" }
+license = {file = "LICENSE.md"}
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Topic :: Software Development :: Build Tools",
@@ -75,7 +70,9 @@ dependencies = [
     "numba>=0.56.0, <=0.61",
 ]
 
-dynamic = ["version"]
+dynamic = [
+    "version",
+]
 
 [project.optional-dependencies]
 dev = [
@@ -102,7 +99,10 @@ docs = [
     "mkdocs-badges",
 ]
 
-notebook = ["jupyter>=1.0.0", "ipywidgets>=7.5.1"]
+notebook = [
+    "jupyter>=1.0.0",
+    "ipywidgets>=7.5.1",
+]
 
 # this provides the recommended pyspark and pyarrow versions for spark to work on pandas-profiling
 # note that if you are using pyspark 2.3 or 2.4 and pyarrow >= 0.15, you might need to
@@ -126,7 +126,9 @@ test = [
     "kaggle",
 ]
 
-unicode = ["tangled-up-in-unicode==0.2.0"]
+unicode= [
+    "tangled-up-in-unicode==0.2.0",
+]
 
 [project.urls]
 Homepage = "https://ydata.ai"

--- a/tests/notebooks/lazy_pipeline.ipynb
+++ b/tests/notebooks/lazy_pipeline.ipynb
@@ -21,7 +21,15 @@
     "\n",
     "# Our package\n",
     "from ydata_profiling import ProfileReport\n",
-    "from ydata_profiling.utils.cache import cache_file"
+    "from ydata_profiling.utils.cache import cache_file\n",
+    "\n",
+    "import nbtest\n",
+    "\n",
+    "# The tests in this notebook only run in the continuous integration pipeline\n",
+    "# in order to run manually uncomment the following two lines:\n",
+    "\n",
+    "# import os\n",
+    "# os.environ['NBTEST_RUN_ASSERTS'] = '1'"
    ]
   },
   {
@@ -48,10 +56,8 @@
     "with capture_output() as out:\n",
     "    profile = ProfileReport(df, title=\"Titanic Dataset\", progress_bar=True, lazy=False)\n",
     "\n",
-    "assert all(\n",
-    "    any(v in s.data[\"text/plain\"] for v in [\"%|\", \"FloatProgress\"]) for s in out.outputs\n",
-    ")\n",
-    "assert len(out.outputs) == 2"
+    "nbtest.assert_true(all(any(v in s.data[\"text/plain\"] for v in [\"%|\", \"FloatProgress\"]) for s in out.outputs))\n",
+    "nbtest.assert_equal(len(out.outputs), 2)"
    ]
   },
   {
@@ -69,22 +75,20 @@
     "        lazy=True,\n",
     "    )\n",
     "\n",
-    "assert len(out.outputs) == 0\n",
+    "nbtest.assert_equal(len(out.outputs), 0)\n",
     "\n",
     "with capture_output() as out:\n",
     "    _ = profile.to_html()\n",
     "\n",
     "\n",
-    "assert all(\n",
-    "    any(v in s.data[\"text/plain\"] for v in [\"%|\", \"FloatProgress\"]) for s in out.outputs\n",
-    ")\n",
-    "assert len(out.outputs) == 3\n",
+    "nbtest.assert_true(all(any(v in s.data[\"text/plain\"] for v in [\"%|\", \"FloatProgress\"]) for s in out.outputs))\n",
+    "nbtest.assert_equal(len(out.outputs), 3)\n",
     "\n",
     "with capture_output() as out:\n",
     "    _ = profile.to_file(\"/tmp/tmpfile.html\")\n",
     "\n",
-    "assert \"Export report to file\" in out.outputs[0].data[\"text/plain\"]\n",
-    "assert len(out.outputs) == 1"
+    "nbtest.assert_in(\"Export report to file\", out.outputs[0].data[\"text/plain\"])\n",
+    "nbtest.assert_equal(len(out.outputs), 1)"
    ]
   },
   {
@@ -96,30 +100,30 @@
     "# Test caching of the iterative building process\n",
     "with capture_output() as out:\n",
     "    profile = ProfileReport(df, title=\"Titanic Dataset\", progress_bar=True, lazy=True)\n",
-    "assert len(out.outputs) == 0\n",
+    "nbtest.assert_equal(len(out.outputs), 0)\n",
     "\n",
     "with capture_output() as out:\n",
     "    profile.description_set\n",
-    "assert len(out.outputs) == 1\n",
+    "nbtest.assert_equal(len(out.outputs), 1)\n",
     "\n",
     "with capture_output() as out:\n",
     "    profile.report\n",
-    "assert len(out.outputs) == 1\n",
+    "nbtest.assert_equal(len(out.outputs), 1)\n",
     "\n",
     "with capture_output() as out:\n",
     "    profile.html\n",
-    "assert len(out.outputs) == 1\n",
+    "nbtest.assert_equal(len(out.outputs), 1)\n",
     "\n",
     "with capture_output() as out:\n",
     "    profile.config.html.style.theme = \"united\"\n",
     "    profile.invalidate_cache(\"rendering\")\n",
     "    profile.to_file(\"/tmp/cache1.html\")\n",
-    "assert len(out.outputs) == 2\n",
+    "nbtest.assert_equal(len(out.outputs), 2)\n",
     "\n",
     "with capture_output() as out:\n",
     "    profile.config.pool_size = 1\n",
     "    profile.html\n",
-    "assert len(out.outputs) == 0\n",
+    "nbtest.assert_equal(len(out.outputs), 0)\n",
     "\n",
     "with capture_output() as out:\n",
     "    profile.config.pool_size = 0\n",
@@ -127,15 +131,29 @@
     "    profile.config.samples.tail = 15\n",
     "    profile.invalidate_cache()\n",
     "    profile.to_file(\"/tmp/cache2.html\")\n",
-    "assert len(out.outputs) == 4"
+    "nbtest.assert_equal(len(out.outputs), 4)"
    ]
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/tests/notebooks/meteorites.ipynb
+++ b/tests/notebooks/meteorites.ipynb
@@ -22,7 +22,15 @@
     "from IPython.utils.capture import capture_output\n",
     "\n",
     "import ydata_profiling\n",
-    "from ydata_profiling.utils.cache import cache_file"
+    "from ydata_profiling.utils.cache import cache_file\n",
+    "\n",
+    "import nbtest\n",
+    "\n",
+    "# The tests in this notebook only run in the continuous integration pipeline\n",
+    "# in order to run manually uncomment the following two lines:\n",
+    "\n",
+    "# import os\n",
+    "# os.environ['NBTEST_RUN_ASSERTS'] = '1'"
    ]
   },
   {
@@ -83,9 +91,9 @@
     "    )\n",
     "    display(pr)\n",
     "\n",
-    "assert len(out.outputs) == 2\n",
-    "assert out.outputs[0].data[\"text/plain\"] == \"<IPython.core.display.HTML object>\"\n",
-    "assert out.outputs[1].data[\"text/plain\"] == \"\""
+    "nbtest.assert_equal(len(out.outputs), 2)\n",
+    "nbtest.assert_equal(out.outputs[0].data[\"text/plain\"], \"<IPython.core.display.HTML object>\")\n",
+    "nbtest.assert_equal(out.outputs[1].data[\"text/plain\"], \"\")"
    ]
   },
   {
@@ -103,10 +111,8 @@
     "        lazy=False,\n",
     "    )\n",
     "\n",
-    "assert all(\n",
-    "    any(v in s.data[\"text/plain\"] for v in [\"%|\", \"FloatProgress\"]) for s in out.outputs\n",
-    ")\n",
-    "assert len(out.outputs) == 2"
+    "nbtest.assert_true(all(any(v in s.data[\"text/plain\"] for v in [\"%|\", \"FloatProgress\"]) for s in out.outputs))\n",
+    "nbtest.assert_equal(len(out.outputs), 2)"
    ]
   },
   {
@@ -119,10 +125,8 @@
     "with capture_output() as out:\n",
     "    pfr.to_file(\"/tmp/example.html\")\n",
     "\n",
-    "assert all(\n",
-    "    any(v in s.data[\"text/plain\"] for v in [\"%|\", \"FloatProgress\"]) for s in out.outputs\n",
-    ")\n",
-    "assert len(out.outputs) == 2"
+    "nbtest.assert_true(all(any(v in s.data[\"text/plain\"] for v in [\"%|\", \"FloatProgress\"]) for s in out.outputs))\n",
+    "nbtest.assert_equal(len(out.outputs), 2)"
    ]
   },
   {
@@ -135,9 +139,9 @@
     "with capture_output() as out:\n",
     "    display(pfr)\n",
     "\n",
-    "assert len(out.outputs) == 2\n",
-    "assert out.outputs[0].data[\"text/plain\"] == \"<IPython.core.display.HTML object>\"\n",
-    "assert out.outputs[1].data[\"text/plain\"] == \"\""
+    "nbtest.assert_equal(len(out.outputs), 2)\n",
+    "nbtest.assert_equal(out.outputs[0].data[\"text/plain\"], \"<IPython.core.display.HTML object>\")\n",
+    "nbtest.assert_equal(out.outputs[1].data[\"text/plain\"], \"\")"
    ]
   }
  ],
@@ -157,9 +161,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/tests/notebooks/titanic.ipynb
+++ b/tests/notebooks/titanic.ipynb
@@ -21,7 +21,15 @@
     "from ipywidgets import widgets\n",
     "\n",
     "from ydata_profiling import ProfileReport\n",
-    "from ydata_profiling.utils.cache import cache_file"
+    "from ydata_profiling.utils.cache import cache_file\n",
+    "\n",
+    "import nbtest\n",
+    "\n",
+    "# The tests in this notebook only run in the continuous integration pipeline\n",
+    "# in order to run manually uncomment the following two lines:\n",
+    "\n",
+    "# import os\n",
+    "# os.environ['NBTEST_RUN_ASSERTS'] = '1'"
    ]
   },
   {
@@ -54,10 +62,9 @@
     "        lazy=False,\n",
     "    )\n",
     "\n",
-    "assert all(\n",
-    "    any(v in s.data[\"text/plain\"] for v in [\"%|\", \"FloatProgress\"]) for s in out.outputs\n",
-    ")\n",
-    "assert len(out.outputs) == 2"
+    "nbtest.assert_true(all(any(v in s.data[\"text/plain\"] for v in [\"%|\", \"FloatProgress\"]) for s in out.outputs))\n",
+    "\n",
+    "nbtest.assert_equal(len(out.outputs), 2)"
    ]
   },
   {
@@ -76,7 +83,7 @@
     "        lazy=False,\n",
     "    )\n",
     "\n",
-    "assert len(out.outputs) == 0"
+    "nbtest.assert_equal(len(out.outputs), 0)"
    ]
   },
   {
@@ -87,14 +94,14 @@
    "source": [
     "# Waiting on issue: https://github.com/computationalmodelling/nbval/issues/136\n",
     "\n",
-    "# The Notebook Widgets Interface\n",
+    "# The Notebook Widgets Interface - faced execution error here, hence, the tests below have been commented\n",
     "# with capture_output() as out:\n",
     "#     profile.to_widgets()\n",
     "\n",
-    "# assert len(out.outputs) == 2\n",
-    "# assert out.outputs[0].data['text/plain'].startswith('Tab(children=(HTML(value=')\n",
-    "# assert out.outputs[1].data['text/plain'] == '<IPython.display.HTML object>'\n",
-    "# assert 'ydata-profiling' in out.outputs[1].data['text/html']"
+    "# nbtest.assert_equal(len(out.outputs), 2)\n",
+    "# nbtest.assert_true(out.outputs[0].data['text/plain'].startswith('Tab(children=(HTML(value='))\n",
+    "# nbtest.assert_equal(out.outputs[1].data['text/plain'], '<IPython.display.HTML object>')\n",
+    "# nbtest.assert_in('ydata-profiling', out.outputs[1].data['text/html'])"
    ]
   },
   {
@@ -107,14 +114,14 @@
     "with capture_output() as out:\n",
     "    profile.to_notebook_iframe()\n",
     "\n",
-    "assert len(out.outputs) == 1\n",
-    "assert out.outputs[0].data[\"text/plain\"] == \"<IPython.core.display.HTML object>\""
+    "nbtest.assert_equal(len(out.outputs), 1)\n",
+    "nbtest.assert_equal(out.outputs[0].data[\"text/plain\"], \"<IPython.core.display.HTML object>\")"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -128,9 +135,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
Closes #1761 

Hi, We are developers of the NBTest framework. We are following up on the previous discussion #1761. We can now use NBTest's assertions directly in the notebooks which were part of your library's tests. Hence, we have replaced `nbval` with `nbtest` in the CI. Please let us know if these changes make sense. We are happy to answer any questions! Thanks!

Description of the changes: 

- Modified all the notebooks in the `tests/notebooks/` directory to utilise NBTest assertions
- Replaced `--nbval` flag with `--nbtest` in the Makefile
- Reordered the test steps to demonstrate NBTest's pytest plugin in the CI (which were not executed due to failing unit tests)
- Updated `pyproject.toml` to include `nbtest-gen` as it's test dependency, instead of `nbval`    

Note: [This notebook](https://github.com/ydataai/ydata-profiling/blob/develop/tests/notebooks/meteorites.ipynb) has some dataset API errors, but the rest of them do work as expected. 