### PR TITLE
allow matplotlib 3.10.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
 dependencies = [
     "scipy>=1.8, <1.17",
     "pandas>1.5, <3.0, !=1.4.0",
-    "matplotlib>=3.5, <=3.10",
+    "matplotlib>=3.5, <3.11",
     "pydantic>=2, <3",
     "PyYAML>=6.0.3, <6.1",
     "jinja2>=3.1.6, <3.2",


### PR DESCRIPTION
I suspect the expression `<=3.10` was intended to allow `3.10.x`, a minor version with several releases since 2024, but it doesn't.

Breaking changes on this branch can be perused @ https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.10.0.html