### PR TITLE
fix: replace deprecated pkg_resources with importlib.metadata (#1816)

### DIFF
--- a/src/ydata_profiling/profile_report.py
+++ b/src/ydata_profiling/profile_report.py
@@ -8,7 +8,7 @@ from ydata_profiling.utils.backend import is_pyspark_installed
 
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
-    import pkg_resources
+    from importlib.metadata import version
 
 if not is_pyspark_installed():
     from typing import TypeVar
@@ -359,7 +359,7 @@ class ProfileReport(SerializeReport, ExpectationsReport):
         """
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            pillow_version = pkg_resources.get_distribution("Pillow").version
+            pillow_version = version("Pillow")
         version_tuple = tuple(map(int, pillow_version.split(".")))
         if version_tuple < (9, 5, 0):
             warnings.warn(


### PR DESCRIPTION
## Problem
`profile_report.py` imports `pkg_resources` directly, which was removed
in `setuptools>=81`. This causes `ModuleNotFoundError` on fresh environments
with modern setuptools.

## Fix
Replaced `pkg_resources.get_distribution("Pillow").version` with
`importlib.metadata.version("Pillow")`, available since Python 3.8.
The `utils/versions.py` file already uses this pattern — this PR
makes `profile_report.py` consistent with it.

## Testing
- Verified import works on Python 3.13 with setuptools>=81
- No existing tests broken

Closes #1816