### PR TITLE
fix: update requires-python to include Python 3.14 and add 3.14 to CI…

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-22.04 ]
-        python-version: ["3.10", "3.11", "3.12", "3.13" ]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14" ]
         pandas: [ "pandas>1.1" ]
         numpy: [ "numpy>=1.21" ]
     runs-on: ${{ matrix.os }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ package_name = "fg-data-profiling"
 
 [project]
 name = "fg-data-profiling"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10,<3.15"
 authors = [
     {name = "YData Labs Inc", email = "opensource@ydata.ai"}
 ]


### PR DESCRIPTION
Fixes #1811

Supersedes #1815 (rebased on updated develop after package rename).

### Changes
- Updated `requires-python` from `<3.14` to `<3.15`
- Added Python 3.14 to CI test matrix in tests.yml

### Testing
- Full test suite passed on Python 3.13.5 (2195 passed, 4 skipped, 0 failures)
- Confirmed working on Python 3.14 by community member (Arch Linux AUR package)