### PR TITLE
fix: replace pkg_resources with importlib.metadata (#1816)

### DIFF
--- a/src/data_profiling/profile_report.py
+++ b/src/data_profiling/profile_report.py
@@ -1,14 +1,19 @@
 import copy
 import json
 import warnings
+
+# Use stdlib `importlib.metadata` instead of `pkg_resources`. The latter
+# was removed in setuptools >= 81 (see
+# https://setuptools.pypa.io/en/latest/history.html#v81-0-0); since
+# pyproject.toml pins ``requires-python = ">=3.10"`` and
+# ``importlib.metadata`` ships with the stdlib from Python 3.8 onward,
+# no fallback is needed here.
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _metadata_version
 from pathlib import Path
 from typing import Any, Optional, Union
 
 from data_profiling.utils.backend import is_pyspark_installed
-
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore")
-    import pkg_resources
 
 if not is_pyspark_installed():
     from typing import TypeVar
@@ -357,14 +362,27 @@ class ProfileReport(SerializeReport, ExpectationsReport):
             output_file: The name or the path of the file to generate including the extension (.html, .json).
             silent: if False, opens the file in the default browser or download it in a Google Colab environment
         """
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            pillow_version = pkg_resources.get_distribution("Pillow").version
-        version_tuple = tuple(map(int, pillow_version.split(".")))
-        if version_tuple < (9, 5, 0):
-            warnings.warn(
-                "Try running command: 'pip install --upgrade Pillow' to avoid ValueError"
-            )
+        # Resolve the installed Pillow version via the stdlib metadata API.
+        # If Pillow is not installed (it's an indirect dependency, so this
+        # is unusual but possible in trimmed environments), skip the warning
+        # rather than crashing the whole report-write path.
+        try:
+            pillow_version = _metadata_version("Pillow")
+        except PackageNotFoundError:
+            pillow_version = None
+        if pillow_version is not None:
+            # Some Pillow pre-releases use non-numeric segments (e.g. "11.0.0a1");
+            # take only the leading numeric components so int() never fails.
+            numeric_parts = []
+            for part in pillow_version.split("."):
+                digits = "".join(c for c in part if c.isdigit())
+                if not digits:
+                    break
+                numeric_parts.append(int(digits))
+            if len(numeric_parts) >= 3 and tuple(numeric_parts[:3]) < (9, 5, 0):
+                warnings.warn(
+                    "Try running command: 'pip install --upgrade Pillow' to avoid ValueError"
+                )
 
         if not isinstance(output_file, Path):
             output_file = Path(str(output_file))

--- a/src/data_profiling/utils/versions.py
+++ b/src/data_profiling/utils/versions.py
@@ -1,10 +1,10 @@
-try:
-    from importlib.metadata import version
-except ImportError:
-    import pkg_resources
-
-    def version(pkg: str) -> str:  # type: ignore
-        return pkg_resources.get_distribution(pkg).version
+# `importlib.metadata.version` is in the stdlib since Python 3.8.
+# pyproject.toml pins `requires-python = ">=3.10,<3.14"`, so the previous
+# `pkg_resources` fallback was dead code under any supported runtime.
+# Removing it also drops a runtime dependency on setuptools, which now
+# raises `ModuleNotFoundError: No module named 'pkg_resources'` on
+# setuptools >= 81 where pkg_resources was removed.
+from importlib.metadata import version
 
 
 def pandas_version() -> list:

--- a/tests/issues/test_issue1816.py
+++ b/tests/issues/test_issue1816.py
@@ -1,0 +1,63 @@
+"""
+Test for issue 1816:
+https://github.com/Data-Centric-AI-Community/fg-data-profiling/issues/1816
+
+`pkg_resources` was removed in setuptools >= 81. Importing
+`data_profiling.profile_report` (or its public re-exports) must not pull
+`pkg_resources` in, or the import chain crashes with
+``ModuleNotFoundError: No module named 'pkg_resources'`` on environments
+where setuptools >= 81 has been installed (e.g. fresh CI runners).
+
+The two regressions guards below are designed so they would fail on the
+pre-fix tree even when ``setuptools`` is present (because the import
+statement would still bring `pkg_resources` into ``sys.modules``), and
+they exercise the actual code path (``ProfileReport.to_file``) that used
+``pkg_resources.get_distribution("Pillow").version``.
+"""
+
+import importlib
+import sys
+
+import pandas as pd
+
+from data_profiling import ProfileReport
+
+
+def test_profile_report_module_does_not_import_pkg_resources():
+    """The module must not pull `pkg_resources` into ``sys.modules``.
+
+    Asserting *non-import* is the load-bearing check: setuptools 81 raises
+    ``ModuleNotFoundError`` from any ``import pkg_resources``, so any
+    transitive import from ``data_profiling.profile_report`` would crash
+    on those environments.
+    """
+    sys.modules.pop("pkg_resources", None)
+    sys.modules.pop("data_profiling.profile_report", None)
+    importlib.import_module("data_profiling.profile_report")
+    assert "pkg_resources" not in sys.modules
+
+
+def test_versions_helper_does_not_import_pkg_resources():
+    """`utils.versions` previously had a `pkg_resources` fallback branch.
+
+    With Python 3.10+ (the project's floor), `importlib.metadata.version`
+    is always available, so the fallback is dead code. Removing it is
+    what closes the issue end-to-end.
+    """
+    sys.modules.pop("pkg_resources", None)
+    sys.modules.pop("data_profiling.utils.versions", None)
+    importlib.import_module("data_profiling.utils.versions")
+    assert "pkg_resources" not in sys.modules
+
+
+def test_to_file_runs_without_pkg_resources(test_output_dir):
+    """End-to-end smoke: writing a report exercises the Pillow-version
+    branch that previously called ``pkg_resources.get_distribution``."""
+    sys.modules.pop("pkg_resources", None)
+    df = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    profile = ProfileReport(df, minimal=True)
+    output_file = test_output_dir / "issue1816.html"
+    profile.to_file(output_file)
+    assert output_file.exists()
+    # `to_file` must not have re-imported `pkg_resources` either.
+    assert "pkg_resources" not in sys.modules


### PR DESCRIPTION
## Summary

Replace the runtime dependency on `pkg_resources` (removed in setuptools 81)
with the stdlib `importlib.metadata`, so `import data_profiling` no longer
crashes on fresh installs that pull in modern setuptools.

Fixes #1816 — *Replace deprecated pkg_resources with importlib.metadata in profile_report.py*.

## Context

`pkg_resources` was removed from setuptools in v81 ([changelog entry][1]).
After Aug 2025, fresh `pip install fg-data-profiling` resolutions on a
clean environment routinely crash at `import` time with
`ModuleNotFoundError: No module named 'pkg_resources'`, because
`src/data_profiling/profile_report.py:11` does `import pkg_resources`
unconditionally and `src/data_profiling/utils/versions.py` keeps a
`pkg_resources` fallback.

That fallback was meant to support Python < 3.8 (where
`importlib.metadata` did not exist), but `pyproject.toml` already pins
`requires-python = ">=3.10,<3.14"` since #1778, so the fallback branch is
dead code under any supported runtime.

The original issue reporter validated the change locally with a 2195-test
green run on Python 3.13.

[1]: https://setuptools.pypa.io/en/latest/history.html#v81-0-0

## Changes

- `src/data_profiling/profile_report.py`: drop `import pkg_resources`,
  use `importlib.metadata.version("Pillow")` in `ProfileReport.to_file`.
  Wrap the lookup in a `PackageNotFoundError` guard (Pillow is an indirect
  dependency, so a trimmed environment without it should warn-and-continue,
  not crash). Parse numeric components defensively so pre-release versions
  like `"11.0.0a1"` don't blow up `int()`.
- `src/data_profiling/utils/versions.py`: drop the `pkg_resources` fallback
  branch. `importlib.metadata.version` is unconditional now.
- `tests/issues/test_issue1816.py` (new): three regression guards.

The targeted comments inline explain why the branch was kept (Pillow may
be absent) and why the numeric-parts loop exists (pre-release segments) so
a reviewer reading the diff cold doesn't have to re-derive the reasoning.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- one-time setup ---
git clone https://github.com/Data-Centric-AI-Community/fg-data-profiling.git /tmp/repro && cd /tmp/repro
python3 -m venv /tmp/repro-venv
source /tmp/repro-venv/bin/activate
pip install --upgrade 'setuptools>=81' pip   # the env that triggers the bug

# --- BEFORE (origin/develop) ---
git checkout origin/develop
pip install -q -e . pytest
python3 -c "import data_profiling"
# Expected: ModuleNotFoundError: No module named 'pkg_resources'
git fetch https://github.com/jbbqqf/fg-data-profiling.git feat/1816-importlib-metadata-pillow
git checkout FETCH_HEAD -- tests/issues/test_issue1816.py
python3 -m pytest tests/issues/test_issue1816.py -v 2>&1 | tail -5
# Expected: collection error / import error before any test runs

# --- AFTER (this PR) ---
git fetch https://github.com/jbbqqf/fg-data-profiling.git feat/1816-importlib-metadata-pillow
git checkout FETCH_HEAD
pip install -q --force-reinstall --no-deps -e .
python3 -c "import data_profiling; print('import OK')"
# Expected: prints "import OK"
python3 -m pytest tests/issues/test_issue1816.py -v 2>&1 | tail -5
# Expected: 3 passed
```

The block above is a single bash run a reviewer can paste verbatim. The
only thing that changes between BEFORE and AFTER is the checked-out git
ref — that's the load-bearing piece of evidence.

## What I ran locally

- `pytest tests/issues/test_issue1816.py -v` → 3/3 passed.
- `pytest tests/unit/test_describe.py tests/unit/test_html_export.py tests/issues/test_issue1816.py` → 33/33 passed.
- `pytest tests/issues/` → 43 passed, 3 skipped, 1 unrelated failure
  (`test_issue147` — needs `pyarrow` which isn't installed in my
  reproducible-build env; same failure on `origin/develop`, not introduced
  by this change).
- Python 3.13.12, setuptools 82.0.1 (>= 81, the version that triggers the
  bug). pkg_resources is genuinely absent in this env, which is why the
  regression test is meaningful.
- `black --check` clean on the three modified files.

GHA on the fork is not enabled, so the upstream `pull-request.yml`
workflow will be the first end-to-end signal across the supported Python
matrix; the pyproject pins `>=3.10,<3.14`, so the fix is in scope for
every supported version.

## Edge cases tested

| # | Scenario | Input | Expected | Verified by |
|---|----------|-------|----------|-------------|
| 1 | setuptools >= 81 (no pkg_resources) | `import data_profiling` | succeeds; pkg_resources never imported | `test_profile_report_module_does_not_import_pkg_resources` |
| 2 | versions helper used elsewhere | `import data_profiling.utils.versions` | succeeds; no pkg_resources | `test_versions_helper_does_not_import_pkg_resources` |
| 3 | end-to-end report write | `ProfileReport(df).to_file("...")` on a 3-row df | writes HTML, sys.modules clean | `test_to_file_runs_without_pkg_resources` |
| 4 | Pillow absent | `importlib.metadata.PackageNotFoundError` | warning skipped, write continues | inline `try/except PackageNotFoundError` (covered by test 3 if Pillow optional) |
| 5 | Pillow pre-release version | `"11.0.0a1"` | numeric part loop short-circuits cleanly | inline `numeric_parts` loop (no separate test, exercised whenever Pillow isn't a final release) |

## Risk / blast radius

- Additive at the import layer — no public API change.
- The Pillow-version warning is preserved, just driven from
  `importlib.metadata`. `pkg_resources` and `importlib.metadata` agree on
  the version string for any package installed via PEP 517.
- One behavior change: if Pillow is somehow not installed, the previous
  code would have raised `pkg_resources.DistributionNotFound` (an
  uncaught crash from inside `to_file`); the new code warns nothing and
  continues. That is the safer default for a Pillow optional path. Worth
  a maintainer's nod, hence the inline comment.

## Release note

```release-note
fix: replace runtime pkg_resources lookups with importlib.metadata so
ProfileReport imports cleanly under setuptools >= 81. (#1816)
```

## Upstream PR checklist (from `.github/PULL_REQUEST_TEMPLATE/pull_request_template.md`)

- [x] `make lint` (black) — clean on the 3 modified files. (Pre-existing
  isort drift on `profile_report.py` that already exists on `develop` is
  not addressed here to keep the diff scoped.)
- [ ] `make docs` — n/a, no doc changes.
- [x] `make test` — `pytest tests/issues/test_issue1816.py -v` → 3/3 passed
  on Python 3.13 with setuptools 82 (the env that triggers the bug).
- [ ] `make examples` — n/a, no example changes.

---

*PR drafted with assistance from Claude Code. The change was reviewed
manually against the upstream codebase on `develop` and the setuptools
v81 release notes. The reproducer block above was used during development;
it is the same one a reviewer can paste verbatim.*
