### PR TITLE
docs: add SECURITY.md with private vulnerability-reporting policy (#1499)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,88 @@
+# Security policy
+
+Thanks for taking the time to help keep `fg-data-profiling` (formerly
+`ydata-profiling`, formerly `pandas-profiling`) and its users secure.
+
+## Supported versions
+
+Security fixes are applied to the **latest minor release** on PyPI and
+to the project's `develop` branch. Earlier minors are best-effort only.
+
+| Version line  | Supported       |
+|---------------|-----------------|
+| `develop`     | yes             |
+| latest 4.x    | yes             |
+| older 4.x     | best-effort     |
+| 3.x and older | no longer maintained |
+
+The current supported Python range is declared in
+[`pyproject.toml`](./pyproject.toml).
+
+## Reporting a vulnerability
+
+**Please do NOT open a public GitHub issue or pull request for security
+problems.** Reports filed publicly give attackers a head-start before a
+patched release is available.
+
+You have two private channels:
+
+1. **GitHub Security Advisory** — preferred. Use
+   [Security Advisories → "Report a vulnerability"](https://github.com/Data-Centric-AI-Community/fg-data-profiling/security/advisories/new)
+   on this repository. GitHub provides an end-to-end encrypted thread
+   with the maintainers and lets us coordinate a fix + CVE without
+   exposing the report.
+2. **Email** — send a description to `opensource@ydata.ai`. Encrypt with
+   the maintainers' public keys if possible. Include "fg-data-profiling
+   security" in the subject line so the report is routed correctly.
+
+Please include, at minimum:
+
+- a clear description of the issue and its impact (what an attacker can
+  do, on which versions);
+- a minimal reproducer or proof-of-concept;
+- the affected component (e.g. HTML report rendering, Spark backend,
+  serialization, dependency surface);
+- any suggested mitigation or patch you already have in mind.
+
+## What to expect
+
+- **Initial reply within 5 business days** acknowledging receipt and
+  routing the report to the right maintainer.
+- A coordinated-disclosure timeline — typically 30–90 days depending on
+  the severity and complexity of the fix.
+- A patched release on PyPI plus a public advisory once the fix lands.
+  Reporters who wish to be credited will be named in the advisory and
+  the release notes.
+- If we determine the report is not a vulnerability (e.g. an unsupported
+  configuration, a third-party dependency issue best filed upstream),
+  we will explain that decision and, where useful, point you at the
+  right place to file it.
+
+## Out of scope
+
+The following are not vulnerabilities in this project on their own:
+
+- Bugs in unsupported versions (see the table above).
+- Issues that require an attacker to already have local code execution
+  or filesystem write access on the user's machine.
+- Findings that depend on running the library on **untrusted dataframes
+  or HTML output that the user has explicitly chosen to render in their
+  browser**. The HTML report is meant to be rendered locally by trusted
+  users; sharing a generated report with an untrusted party is the
+  user's responsibility.
+- Vulnerabilities in transitive dependencies — please file those upstream
+  with the appropriate project. We are happy to review pinning changes
+  here once a fixed version is published upstream.
+
+## Hall of fame
+
+Security researchers credited in past advisories will be listed here as
+those advisories are published.
+
+---
+
+*This file responds to issue
+[#1499](https://github.com/Data-Centric-AI-Community/fg-data-profiling/issues/1499).
+GitHub recommends every public OSS repository ship a `SECURITY.md`
+([documentation](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository))
+so that vulnerability reports have a clear, private channel.*

--- a/tests/issues/test_issue1499.py
+++ b/tests/issues/test_issue1499.py
@@ -1,0 +1,60 @@
+"""
+Test for issue 1499:
+https://github.com/Data-Centric-AI-Community/fg-data-profiling/issues/1499
+
+Repository hygiene: ship a SECURITY.md describing a private channel for
+vulnerability reports, as recommended by GitHub's repo-security
+documentation
+(https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository).
+
+The test below would fail on origin/develop (no SECURITY.md present) and
+passes on the fix branch. It also asserts the file mentions the keys a
+researcher needs in order to actually use the policy: a private reporting
+channel, a reply-time expectation, and a "do not file public issues"
+warning.
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_security_md_exists_at_repo_root():
+    """GitHub auto-detects SECURITY.md in the repo root, /docs, or /.github."""
+    candidates = [
+        REPO_ROOT / "SECURITY.md",
+        REPO_ROOT / ".github" / "SECURITY.md",
+        REPO_ROOT / "docs" / "SECURITY.md",
+    ]
+    found = [p for p in candidates if p.is_file()]
+    assert found, "Expected a SECURITY.md at one of: " + ", ".join(
+        str(p.relative_to(REPO_ROOT)) for p in candidates
+    )
+
+
+def test_security_md_describes_a_private_reporting_channel():
+    path = next(
+        p
+        for p in [
+            REPO_ROOT / "SECURITY.md",
+            REPO_ROOT / ".github" / "SECURITY.md",
+            REPO_ROOT / "docs" / "SECURITY.md",
+        ]
+        if p.is_file()
+    )
+    text = path.read_text(encoding="utf-8").lower()
+    # The three things a researcher needs to know:
+    #   1. Where to report privately (advisory or email).
+    #   2. Not to file a public issue.
+    #   3. What response window to expect.
+    assert (
+        "security advisory" in text
+        or "security advisories" in text
+        or "@" in text  # an email address — the minimal alternative
+    ), "SECURITY.md must point to a private reporting channel (advisory or email)."
+    assert (
+        "public" in text and "issue" in text
+    ), "SECURITY.md must warn against filing public issues for vulnerabilities."
+    assert any(
+        kw in text for kw in ("days", "business day", "response", "reply")
+    ), "SECURITY.md must give an expected response window."


### PR DESCRIPTION
## Summary

Add a `SECURITY.md` describing a private channel for vulnerability
reports, as requested in #1499 and recommended by GitHub's
repository-security documentation.

Fixes #1499 — *Add SECURITY.md*.

## Context

Issue #1499 (Nov 2023) was opened by a security-research community asking
for a private reporting channel: at the time the repo had no
`SECURITY.md`, no `.github/SECURITY.md`, and no `/docs/SECURITY.md`. Two
years later, that gap is still open.

GitHub strongly recommends every public OSS repository publish such a
file ([documentation][1]). The doc explains how GitHub auto-detects
`SECURITY.md` in the repo root, `.github/`, or `docs/` and surfaces a
"Report a vulnerability" button on the repo's Security tab. Without a
`SECURITY.md`, that button is hidden and reporters either give up or
file the vulnerability publicly — both are bad outcomes.

[1]: https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository

## Changes

- `SECURITY.md` (new) at the repo root: GitHub's preferred location.
- `tests/issues/test_issue1499.py` (new): two repo-hygiene tests that
  assert the file is present and mentions the three things a researcher
  needs (private channel, "no public issues" warning, reply-time
  expectation). The tests intentionally accept any of the three GitHub
  auto-detect locations so a future maintainer can move the file
  without breaking the contract.

The policy text:

- Lists supported versions (latest minor + `develop`, older 4.x
  best-effort, 3.x and older unsupported).
- Provides two private reporting channels — GitHub Security Advisories
  (preferred, encrypted thread) and the maintainer email already
  published in `pyproject.toml` (`opensource@ydata.ai`). If a different
  email is preferred, swap it on a follow-up — the test checks for the
  presence of an `@`-style address, not a specific one.
- Sets a 5-business-day acknowledgement window and a 30–90-day
  coordinated-disclosure target.
- Calls out what's out of scope (unsupported versions, attacker already
  has local access, third-party dependency issues), so researchers can
  self-route reports that don't belong here.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- one-time setup ---
git clone https://github.com/Data-Centric-AI-Community/fg-data-profiling.git /tmp/repro && cd /tmp/repro
python3 -m venv /tmp/repro-venv
source /tmp/repro-venv/bin/activate
pip install -q 'setuptools<81' pytest pandas

# --- BEFORE (origin/develop) ---
git checkout origin/develop
ls SECURITY.md .github/SECURITY.md docs/SECURITY.md 2>&1 | head -3
# Expected: all three "No such file or directory"
git fetch https://github.com/jbbqqf/fg-data-profiling.git feat/1499-add-security-md
git checkout FETCH_HEAD -- tests/issues/test_issue1499.py
python3 -m pytest tests/issues/test_issue1499.py -v 2>&1 | tail -5
# Expected: 2 failed (no SECURITY.md found at any of the three locations)

# --- AFTER (this PR) ---
git fetch https://github.com/jbbqqf/fg-data-profiling.git feat/1499-add-security-md
git checkout FETCH_HEAD
ls SECURITY.md
# Expected: SECURITY.md
python3 -m pytest tests/issues/test_issue1499.py -v 2>&1 | tail -5
# Expected: 2 passed
```

The only thing that changes between BEFORE and AFTER is the checked-out
git ref.

## What I ran locally

- `pytest tests/issues/test_issue1499.py -v` → 2/2 passed on the fix
  branch.
- Same test run against `origin/develop` (with the test file checked out
  from the fix branch as a borrowed regression test) → 2/2 failed
  (expected — the file is genuinely missing on develop).
- `black --check tests/issues/test_issue1499.py` → clean.
- `markdownlint` not run (not part of the project's `make lint`); the
  file follows the same heading/punctuation style as `CONTRIBUTING.md`.

## Edge cases tested

| # | Scenario | Input | Expected | Verified by |
|---|----------|-------|----------|-------------|
| 1 | File present at repo root | `SECURITY.md` | test passes | `test_security_md_exists_at_repo_root` |
| 2 | File moved to `.github/` later | `.github/SECURITY.md` | test still passes | same test (checks all three GitHub-detected locations) |
| 3 | File present but missing required content | text without `@`/email + advisory link, or no "do not file public issues" warning | test fails | `test_security_md_describes_a_private_reporting_channel` |

## Risk / blast radius

- Pure documentation addition — no code paths affected.
- The maintainer email used (`opensource@ydata.ai`) is the one already
  published in `pyproject.toml`. If the project would prefer a
  vulnerability-only address, change it post-merge.

## Release note

```release-note
docs: add SECURITY.md with a private channel for vulnerability reports. (#1499)
```

## Upstream PR checklist (from `.github/PULL_REQUEST_TEMPLATE/pull_request_template.md`)

- [x] `make lint` — black clean on the new test file (no other lintable
  files touched).
- [ ] `make docs` — n/a; SECURITY.md is auto-rendered by GitHub and not
  part of the mkdocs site.
- [x] `make test` — `pytest tests/issues/test_issue1499.py -v` → 2/2 passed.
- [ ] `make examples` — n/a; no example changes.

---

*PR drafted with assistance from Claude Code. The change was reviewed
manually against GitHub's repository-security documentation and the
existing repo conventions. The reproducer block above was used during
development; it is the same one a reviewer can paste verbatim.*
