### PR TITLE
test: add regression test for extreme memory usage (issue #1749)

### DIFF
--- a/4230aem.py
+++ b/4230aem.py
@@ -1,0 +1,8 @@
+import numpy as np
+import pandas as pd
+from ydata_profiling import ProfileReport
+
+data = np.random.uniform(size=6)
+data[0] = 1e16
+df = pd.DataFrame(dict(a=data))
+ProfileReport(df, tsmode=False, lazy=False)

--- a/tests/test_issue.py
+++ b/tests/test_issue.py
@@ -1,0 +1,22 @@
+import numpy as np
+import pandas as pd
+import pytest
+from data_profiling import ProfileReport
+
+
+def test_extreme_memory_usage_issue_1749():
+    """
+    Regression test for Issue #1749.
+    Ensures that extreme outliers (e.g., 1e16) do not cause a MemoryError.
+    """
+    data = np.random.uniform(size=6)
+    data[0] = 1e16
+    df = pd.DataFrame(dict(a=data))
+
+    try:
+        # Пробуем сгенерировать структуру отчета
+        report = ProfileReport(df, tsmode=False, lazy=False)
+        report.get_description()
+    except MemoryError:
+        # Если вдруг ошибка вернется, тест об этом сообщит
+        pytest.fail("ProfileReport raised MemoryError on extreme data values (Issue #1749)")


### PR DESCRIPTION
Added a regression test to ensure that extreme data outliers do not cause a MemoryError when generating the profile report.

I could not reproduce the original bug on the latest develop branch, so it appears the underlying issue was resolved indirectly by other updates. This test ensures the behavior remains stable.
Closes #1749