### PR TITLE
security: add timeouts to HTTP requests to prevent DoS

### DIFF
--- a/src/data_profiling/utils/cache.py
+++ b/src/data_profiling/utils/cache.py
@@ -2,7 +2,10 @@
 import zipfile
 from pathlib import Path
 
-from requests import get as get_file
+from functools import partial
+from requests import get as _get_file
+
+get_file = partial(_get_file, timeout=30)
 
 from data_profiling.utils.paths import get_data_path
 

--- a/src/data_profiling/utils/common.py
+++ b/src/data_profiling/utils/common.py
@@ -102,7 +102,7 @@ def analytics_features(
                 f"&dbx={dbx}"
             )
 
-            requests.get(request_message)
+            requests.get(request_message, timeout=30)
 
 
 def is_running_in_databricks():


### PR DESCRIPTION
This PR fixes a denial-of-service vulnerability where HTTP requests could hang indefinitely.

**CWE:** CWE-400 (Uncontrolled Resource Consumption)
**Files:** src/data_profiling/utils/cache.py, src/data_profiling/utils/common.py

Multiple requests.get() and get_file() calls did not specify a timeout parameter. If a malicious or unresponsive server is encountered, the request hangs forever, consuming a thread and potentially blocking the application.

**Fix:** Added timeout=30 to all HTTP request calls.