### PR TITLE
fix: handle string date indexes in gap stats

### DIFF
--- a/src/data_profiling/model/pandas/describe_timeseries_pandas.py
+++ b/src/data_profiling/model/pandas/describe_timeseries_pandas.py
@@ -173,12 +173,30 @@ def compute_gap_stats(series: pd.Series) -> pd.Series:
         A series with the gaps intervals.
     """
 
+    empty_stats = {
+        "min": 0,
+        "max": 0,
+        "mean": 0,
+        "std": 0,
+        "series": series,
+        "gaps": [],
+        "n_gaps": 0,
+    }
+
     gap = series.dropna()
     index_name = gap.index.name if gap.index.name else "index"
     gap = gap.reset_index()[index_name]
     gap.index.name = None
 
     is_datetime = isinstance(series.index, pd.DatetimeIndex)
+    if not is_datetime and not pd.api.types.is_numeric_dtype(gap):
+        datetime_gap = pd.to_datetime(gap, errors="coerce")
+        if datetime_gap.notna().all():
+            gap = datetime_gap
+            is_datetime = True
+        else:
+            return empty_stats
+
     gap_stats, gaps = identify_gaps(gap, is_datetime)
     has_gaps = len(gap_stats) > 0
 

--- a/tests/unit/test_time_series.py
+++ b/tests/unit/test_time_series.py
@@ -3,6 +3,7 @@ import pandas as pd
 import pytest
 
 from data_profiling import ProfileReport
+from data_profiling.model.pandas.describe_timeseries_pandas import compute_gap_stats
 
 
 @pytest.fixture
@@ -76,6 +77,21 @@ def test_timeseries_with_sortby(sample_ts_df):
     html = profile.to_html()
     assert "date" in html
     assert profile.config.vars.timeseries.sortby == "date"
+
+
+def test_timeseries_gap_stats_with_string_date_index():
+    # GH#1773
+    dates = pd.date_range("2023-01-01", periods=10, freq="D").tolist()
+    dates.append(pd.Timestamp("2023-01-20"))
+    series = pd.Series(
+        np.arange(11, dtype=float),
+        index=pd.Index([date.strftime("%Y-%m-%d") for date in dates], name="Date Local"),
+    )
+
+    gap_stats = compute_gap_stats(series)
+
+    assert gap_stats["n_gaps"] == 1
+    assert gap_stats["min"] == pd.Timedelta(days=10)
 
 
 def test_timeseries_without_sortby(sample_ts_df):


### PR DESCRIPTION
## Summary

- handle string date indexes when computing time series gap stats
- convert parseable string index values to datetimes before calling `diff()`
- return empty gap stats for non-numeric, non-datetime, non-parseable indexes instead of raising
- add a regression test for string date indexes

Closes #1773.

## Checks

- `python3 -m py_compile src/data_profiling/model/pandas/describe_timeseries_pandas.py tests/unit/test_time_series.py`
- `git diff --check`

I could not run the pytest target locally in this Codex environment because `pytest` and the project runtime dependencies, including `pandas`, are not installed.
