### PR TITLE
Fix KeyError: 'n_invalid_dates' when profiling a Spark date column

### DIFF
--- a/src/data_profiling/model/spark/describe_date_spark.py
+++ b/src/data_profiling/model/spark/describe_date_spark.py
@@ -48,4 +48,16 @@ def describe_date_1d_spark(
     bin_edges, hist = df.select(col_name).rdd.flatMap(lambda x: x).histogram(bins_arg)
 
     summary.update({"histogram": (array(hist), array(bin_edges))})
+
+    # A Spark date/timestamp column is type-enforced, so there are no
+    # unparseable "invalid" dates (unlike the pandas string-coercion path). Set
+    # the same keys the pandas backend produces and the shared date renderer
+    # reads, so rendering the report doesn't raise ``KeyError: 'n_invalid_dates'``.
+    summary.update(
+        {
+            "invalid_dates": 0,
+            "n_invalid_dates": 0,
+            "p_invalid_dates": 0.0,
+        }
+    )
     return config, df, summary

--- a/src/data_profiling/report/structure/variables/render_date.py
+++ b/src/data_profiling/report/structure/variables/render_date.py
@@ -60,12 +60,12 @@ def render_date(config: Settings, summary: Dict[str, Any]) -> Dict[str, Any]:
             {"name": "Maximum", "value": fmt(summary["max"]), "alert": False},
             {
                 "name": "Invalid dates",
-                "value": fmt(summary["n_invalid_dates"]),
+                "value": fmt(summary.get("n_invalid_dates", 0)),
                 "alert": False,
             },
             {
                 "name": "Invalid dates (%)",
-                "value": fmt_percent(summary["p_invalid_dates"]),
+                "value": fmt_percent(summary.get("p_invalid_dates", 0.0)),
                 "alert": False,
             },
         ],

--- a/tests/backends/spark_backend/test_issue1759.py
+++ b/tests/backends/spark_backend/test_issue1759.py
@@ -1,0 +1,36 @@
+"""
+Test for issue 1759:
+https://github.com/ydataai/ydata-profiling/issues/1759
+
+Rendering the HTML report for a Spark DataFrame with a date/timestamp column
+used to raise ``KeyError: 'n_invalid_dates'``: the Spark date describe never set
+the ``invalid_dates`` / ``n_invalid_dates`` / ``p_invalid_dates`` keys that the
+shared (backend-agnostic) date renderer reads.
+"""
+
+import datetime
+
+from pyspark.sql import types as T
+
+from data_profiling import ProfileReport
+
+
+def test_spark_date_column_report_does_not_keyerror(test_output_dir, spark_session):
+    spark = spark_session
+
+    schema = T.StructType(
+        [
+            T.StructField("id", T.IntegerType(), True),
+            T.StructField("event_date", T.DateType(), True),
+        ]
+    )
+    data = [
+        (i, datetime.date(2020, 1, 1) + datetime.timedelta(days=i)) for i in range(30)
+    ]
+    test_df = spark.createDataFrame(data, schema=schema)
+
+    profile = ProfileReport(test_df, title="spark_date", explorative=True)
+    output_file = test_output_dir / "spark_date.html"
+    profile.to_file(output_file)
+
+    assert output_file.exists()


### PR DESCRIPTION
## Problem

Fixes #1759.

Profiling a Spark DataFrame with a `DateType`/`TimestampType` column and rendering the HTML report crashes with `KeyError: 'n_invalid_dates'`.

Root cause is a backend-parity gap:
- The **pandas** date describe (`describe_date_pandas.py`) sets `invalid_dates`, `n_invalid_dates` and `p_invalid_dates`.
- The **Spark** equivalent (`describe_date_1d_spark`) computes min/max/range/histogram but **never sets those three keys**.
- The date renderer (`render_date.py`) is backend-agnostic and reads `summary["n_invalid_dates"]` / `summary["p_invalid_dates"]` **unconditionally** (direct subscript), so the Spark path has no fallback → guaranteed `KeyError`.

(The crash only fires when the column is typed as `DateType`/`TimestampType`; a string column routes to the categorical path and dodges it — which explains the pandas-vs-spark confusion in the issue thread.)

## Fix

- Set `invalid_dates` / `n_invalid_dates` / `p_invalid_dates` in `describe_date_1d_spark`. A Spark date/timestamp column is type-enforced, so unlike the pandas string→datetime coercion path there are no unparseable "invalid" dates — the parity-correct values are `0`.
- Belt-and-suspenders: read those keys with `.get(..., default)` in `render_date.py` so no future backend can re-introduce this crash.

## Tests

`tests/backends/spark_backend/test_issue1759.py` profiles a Spark DataFrame with a `DateType` column and writes the report, asserting it renders without error (it raised `KeyError` before this change).

> Note: I don't have a Spark/JVM runtime locally, so I verified the fix by tracing the code paths (Spark describe omits the keys ↔ the shared renderer reads them unconditionally ↔ the pandas describe sets them) and confirming nothing else in `src/` populates these keys. CI's Spark backend job is the end-to-end check. Happy to adjust the test if you'd prefer a different shape.